### PR TITLE
exception 처리 구현

### DIFF
--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/BadRequestException.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/BadRequestException.java
@@ -1,8 +1,0 @@
-package com.pray2you.p2uhomepage.global.exception;
-
-public class BadRequestException extends RuntimeException{
-    public BadRequestException(String message) {
-        super(message);
-    }
-
-}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/CommonErrorCode.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/CommonErrorCode.java
@@ -1,0 +1,20 @@
+package com.pray2you.p2uhomepage.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
+    REQUEST_METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "This request method not supported"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    NOT_EXIST_URL(HttpStatus.NOT_FOUND, "Url does not exist"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/ErrorCode.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/ErrorCode.java
@@ -1,0 +1,10 @@
+package com.pray2you.p2uhomepage.global.exception.ErrorCode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String name();
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/UserErrorCode.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/UserErrorCode.java
@@ -1,0 +1,16 @@
+package com.pray2you.p2uhomepage.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    NOT_MATCHED_REDIRECT_URI(HttpStatus.BAD_REQUEST, "Redirect URIs are not matched"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorResponse.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorResponse.java
@@ -1,0 +1,38 @@
+package com.pray2you.p2uhomepage.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+    private final int status;
+    private final String error;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationError {
+
+        private final String field;
+        private final String message;
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/GlobalExceptionHandler.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,133 @@
+package com.pray2you.p2uhomepage.global.exception;
+
+import com.pray2you.p2uhomepage.global.exception.ErrorCode.CommonErrorCode;
+import com.pray2you.p2uhomepage.global.exception.ErrorCode.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(RestApiException.class)
+    public ResponseEntity<Object> handleCustomException(RestApiException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException e) {
+        log.warn("handleIllegalArgument", e);
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @Override
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<Object> handleNoHandlerFoundException(
+            NoHandlerFoundException e,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        log.warn("handleNoHandlerFound", e);
+        ErrorCode errorCode = CommonErrorCode.NOT_EXIST_URL;
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(errorCode.getMessage())
+                .append(" : ")
+                .append(e.getHttpMethod())
+                .append(" ")
+                .append(e.getRequestURL());
+
+        return handleExceptionInternal(errorCode, sb.toString());
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        log.warn("handleIllegalArgument", e);
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(e, errorCode);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException e,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        log.warn("handleHttpRequestMethodNotSupported", e);
+        ErrorCode errorCode = CommonErrorCode.REQUEST_METHOD_NOT_SUPPORTED;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> handleAllException(Exception ex) {
+        log.warn("handleAllException", ex);
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return handleExceptionInternal(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .error(errorCode.name())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode, message));
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode, String message) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .error(errorCode.name())
+                .message(message)
+                .build();
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(BindException e, ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(BindException e, ErrorCode errorCode) {
+        List<ErrorResponse.ValidationError> validationErrorList = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .collect(Collectors.toList());
+
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .error(errorCode.name())
+                .message(errorCode.getMessage())
+                .errors(validationErrorList)
+                .build();
+    }
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/RestApiException.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/RestApiException.java
@@ -1,0 +1,13 @@
+package com.pray2you.p2uhomepage.global.exception;
+
+import com.pray2you.p2uhomepage.global.exception.ErrorCode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/security/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/security/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,6 +1,7 @@
 package com.pray2you.p2uhomepage.global.security.handler;
 
-import com.pray2you.p2uhomepage.global.exception.BadRequestException;
+import com.pray2you.p2uhomepage.global.exception.ErrorCode.UserErrorCode;
+import com.pray2you.p2uhomepage.global.exception.RestApiException;
 import com.pray2you.p2uhomepage.global.security.jwt.JwtTokenProvider;
 import com.pray2you.p2uhomepage.global.security.repository.CookieAuthorizationRequestRepository;
 import com.pray2you.p2uhomepage.global.security.util.CookieUtil;
@@ -48,7 +49,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .map(Cookie::getValue);
 
         if (redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
-            throw new BadRequestException("redirect URIs are not matched");
+            throw new RestApiException(UserErrorCode.NOT_MATCHED_REDIRECT_URI);
         }
         String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
         String accessToken = tokenProvider.createAccessToken(authentication);


### PR DESCRIPTION
@RestControllerAdvice 어노테이션을 활용하여 전역 exception 관리
api 존재하지 않을 경우, http method가 잘못된 경우도 일관된 exception 처리
customException 생성 후, Exception을 커스터마이징하여 처리할 수 있게 하고, 일관된 반환 값 제공할 수 있게 구현