### PR TITLE
유저 승인 api 구현

### DIFF
--- a/p2uhomepage/build.gradle
+++ b/p2uhomepage/build.gradle
@@ -49,9 +49,13 @@ dependencies {
 	//Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'com.google.code.gson:gson'
 
 	//mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	//validation check
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.6'
 
 	// https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/P2uhomepageApplication.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/P2uhomepageApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class P2uhomepageApplication {
 
 	public static void main(String[] args) {

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/attendance/entity/Attendance.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/attendance/entity/Attendance.java
@@ -1,6 +1,7 @@
 package com.pray2you.p2uhomepage.domain.attendance.entity;
 
 import com.pray2you.p2uhomepage.domain.user.entity.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +12,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Attendance {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/board/entity/Board.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/board/entity/Board.java
@@ -2,6 +2,7 @@ package com.pray2you.p2uhomepage.domain.board.entity;
 
 import com.pray2you.p2uhomepage.domain.user.entity.User;
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Board extends BaseTimeEntity {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/detailpoint/entity/DetailPoint.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/detailpoint/entity/DetailPoint.java
@@ -1,6 +1,7 @@
 package com.pray2you.p2uhomepage.domain.detailpoint.entity;
 
 import com.pray2you.p2uhomepage.domain.totalpoint.entity.TotalPoint;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class DetailPoint {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/event/entity/Event.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/event/entity/Event.java
@@ -1,6 +1,7 @@
 package com.pray2you.p2uhomepage.domain.event.entity;
 
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Event extends BaseTimeEntity {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/item/entity/Item.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/item/entity/Item.java
@@ -1,6 +1,7 @@
 package com.pray2you.p2uhomepage.domain.item.entity;
 
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Item extends BaseTimeEntity {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/controller/MemberApprovalController.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/controller/MemberApprovalController.java
@@ -1,0 +1,51 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.controller;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.request.CreateMemberApprovalRequestDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.CreateMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.DeleteMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.ReadMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.service.MemberApprovalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberApprovalController {
+
+    private final MemberApprovalService memberApprovalService;
+
+    @PostMapping("/api/admin/member-approvals")
+    public ResponseEntity<Map<String, Object>> createMemberApprovals(
+            @Validated @RequestBody CreateMemberApprovalRequestDTO createMemberApprovalRequestDTO) {
+        CreateMemberApprovalResponseDTO responseDTO = memberApprovalService.createMemberApprovals(createMemberApprovalRequestDTO);
+        Map<String, Object> result = new HashMap<>();
+        result.put("msg", "해당 멤버가 승인되었습니다.");
+        result.put("data", responseDTO);
+        return ResponseEntity.ok().body(result);
+    }
+
+    @DeleteMapping("/api/admin/member-approvals/{githubId}")
+    public ResponseEntity<Map<String, Object>> deleteMemberApprovals(@PathVariable(value = "githubId") String githubId) {
+        DeleteMemberApprovalResponseDTO responseDTO = memberApprovalService.deleteMemberApprovals(githubId);
+        Map<String, Object> result = new HashMap<>();
+        result.put("msg", "해당 멤버가 삭제되었습니다.");
+        result.put("data", responseDTO);
+        return ResponseEntity.ok().body(result);
+    }
+
+    @GetMapping("api/admin/member-approvals")
+    public ResponseEntity<Map<String, Object>> getAllMemberApprovals(Pageable pageable){
+        Page<ReadMemberApprovalResponseDTO> memberApprovals = memberApprovalService.getAllMemberApprovals(pageable);
+        Map<String, Object> result = new HashMap<>();
+        result.put("msg", "전체 승인멤버가 조회되었습니다.");
+        result.put("data", memberApprovals);
+        return ResponseEntity.ok().body(result);
+    }
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/request/CreateMemberApprovalRequestDTO.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/request/CreateMemberApprovalRequestDTO.java
@@ -1,0 +1,22 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.dto.request;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.entity.MemberApproval;
+import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateMemberApprovalRequestDTO {
+    @NotBlank()
+    private String githubId;
+    @NotBlank
+    private String username;
+
+    public MemberApproval toEntity(){
+        return new MemberApproval(githubId, username, ApprovalStatus.APPROVED);
+    }
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/response/CreateMemberApprovalResponseDTO.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/response/CreateMemberApprovalResponseDTO.java
@@ -1,0 +1,39 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.dto.response;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.entity.MemberApproval;
+import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CreateMemberApprovalResponseDTO {
+    private Long memberApprovalId;
+    private String githubId;
+    private String username;
+    private ApprovalStatus status;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+
+    @Builder
+    public CreateMemberApprovalResponseDTO(Long memberApprovalId, String githubId, String username, ApprovalStatus status, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+        this.memberApprovalId = memberApprovalId;
+        this.githubId = githubId;
+        this.username = username;
+        this.status = status;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    public static CreateMemberApprovalResponseDTO toDTO(MemberApproval memberApproval){
+        return builder()
+                .memberApprovalId(memberApproval.getId())
+                .githubId(memberApproval.getGithubId())
+                .username(memberApproval.getUsername())
+                .status(memberApproval.getStatus())
+                .createdDate(memberApproval.getCreatedDate())
+                .modifiedDate(memberApproval.getModifiedDate())
+                .build();
+    }
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/response/DeleteMemberApprovalResponseDTO.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/response/DeleteMemberApprovalResponseDTO.java
@@ -1,0 +1,36 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.dto.response;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.entity.MemberApproval;
+import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class DeleteMemberApprovalResponseDTO {
+    public String githubId;
+    public String username;
+    public ApprovalStatus status;
+    public LocalDateTime createDate;
+    public LocalDateTime deletedDate;
+
+    @Builder
+    public DeleteMemberApprovalResponseDTO(String githubId, String username, ApprovalStatus status, LocalDateTime createDate, LocalDateTime deletedDate) {
+        this.githubId = githubId;
+        this.username = username;
+        this.status = status;
+        this.createDate = createDate;
+        this.deletedDate = deletedDate;
+    }
+
+    public static DeleteMemberApprovalResponseDTO toDTO(MemberApproval memberApproval){
+        return builder()
+                .githubId(memberApproval.getGithubId())
+                .username(memberApproval.getUsername())
+                .status(memberApproval.getStatus())
+                .createDate(memberApproval.getCreatedDate())
+                .deletedDate(memberApproval.getModifiedDate())
+                .build();
+    }
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/response/ReadMemberApprovalResponseDTO.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/dto/response/ReadMemberApprovalResponseDTO.java
@@ -1,0 +1,40 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.dto.response;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.entity.MemberApproval;
+import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.lang.reflect.Member;
+import java.time.LocalDateTime;
+
+@Getter
+public class ReadMemberApprovalResponseDTO {
+    public Long memberApprovalId;
+    public String githubId;
+    public String username;
+    public ApprovalStatus status;
+    public LocalDateTime createdDate;
+    public LocalDateTime modifiedDate;
+
+    @Builder
+    public ReadMemberApprovalResponseDTO(Long memberApprovalId, String githubId, String username, ApprovalStatus status, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+        this.memberApprovalId = memberApprovalId;
+        this.githubId = githubId;
+        this.username = username;
+        this.status = status;
+        this.createdDate = createdDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    public static ReadMemberApprovalResponseDTO toDTO(MemberApproval memberApproval){
+        return builder()
+                .memberApprovalId(memberApproval.getId())
+                .githubId(memberApproval.getGithubId())
+                .username(memberApproval.getUsername())
+                .status(memberApproval.getStatus())
+                .createdDate(memberApproval.getCreatedDate())
+                .modifiedDate(memberApproval.getModifiedDate())
+                .build();
+    }
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/entity/MemberApproval.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/entity/MemberApproval.java
@@ -2,13 +2,14 @@ package com.pray2you.p2uhomepage.domain.memberapproval.entity;
 
 import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class MemberApproval extends BaseTimeEntity {
 
@@ -30,5 +31,13 @@ public class MemberApproval extends BaseTimeEntity {
         this.githubId = githubId;
         this.username = username;
         this.status = status;
+    }
+
+    public void delete(){
+        this.status = ApprovalStatus.DELETED;
+    }
+
+    public void create(){
+        this.status = ApprovalStatus.APPROVED;
     }
 }

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/repository/MemberApprovalRepository.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/repository/MemberApprovalRepository.java
@@ -1,0 +1,14 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.repository;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.entity.MemberApproval;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberApprovalRepository extends JpaRepository<MemberApproval, Long> {
+
+    boolean existsByGithubId(String githubId);
+    Optional<MemberApproval> findByGithubId(String githubId);
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/service/MemberApprovalService.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/memberapproval/service/MemberApprovalService.java
@@ -1,0 +1,66 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.service;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.request.CreateMemberApprovalRequestDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.CreateMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.DeleteMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.ReadMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.entity.MemberApproval;
+import com.pray2you.p2uhomepage.domain.memberapproval.repository.MemberApprovalRepository;
+import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
+import com.pray2you.p2uhomepage.global.exception.ErrorCode.UserErrorCode;
+import com.pray2you.p2uhomepage.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberApprovalService {
+
+    private final MemberApprovalRepository memberApprovalRepository;
+
+    public CreateMemberApprovalResponseDTO createMemberApprovals(CreateMemberApprovalRequestDTO requestDTO){
+
+        MemberApproval memberApproval = memberApprovalRepository.findByGithubId(requestDTO.getGithubId())
+                .orElse(requestDTO.toEntity());
+
+        if (memberApproval.getStatus() == ApprovalStatus.JOINED) {
+            throw new RestApiException(UserErrorCode.DUPLICATE_APPROVAL_EXCEPTION);
+        }
+
+        //이미 delete되었던 approval일 경우, 다시 생성
+        memberApproval.create();
+        MemberApproval savedMemberApproval = memberApprovalRepository.save(memberApproval);
+
+        return CreateMemberApprovalResponseDTO.toDTO(savedMemberApproval);
+    }
+
+    public DeleteMemberApprovalResponseDTO deleteMemberApprovals(String githubId){
+
+        MemberApproval memberApproval = memberApprovalRepository.findByGithubId(githubId)
+                .orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_APPROVAL_EXCEPTION));
+
+        if (memberApproval.getStatus() == ApprovalStatus.DELETED) {
+            throw new RestApiException(UserErrorCode.NOT_EXIST_APPROVAL_EXCEPTION);
+        }
+
+        //삭제 상태로 변경
+        memberApproval.delete();
+
+        MemberApproval deletedMemberApproval = memberApprovalRepository.save(memberApproval);
+
+        return DeleteMemberApprovalResponseDTO.toDTO(deletedMemberApproval);
+    }
+
+    public Page<ReadMemberApprovalResponseDTO> getAllMemberApprovals(Pageable pageable){
+        Page<MemberApproval> memberApprovals = memberApprovalRepository.findAll(pageable);
+        log.info("조회완료");
+        return memberApprovals
+                .map(ReadMemberApprovalResponseDTO::toDTO);
+    }
+
+
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/model/ApprovalStatus.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/model/ApprovalStatus.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 public enum ApprovalStatus {
 
         APPROVED("APPROVED"),
-        JOINED("JOINED");
+        JOINED("JOINED"),
+        DELETED("DELETED")
+        ;
 
         String status;
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/order/entity/Order.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/order/entity/Order.java
@@ -3,6 +3,7 @@ package com.pray2you.p2uhomepage.domain.order.entity;
 import com.pray2you.p2uhomepage.domain.item.entity.Item;
 import com.pray2you.p2uhomepage.domain.user.entity.User;
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "`order`")
 public class Order extends BaseTimeEntity {

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/rank/entity/Rank.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/rank/entity/Rank.java
@@ -1,6 +1,7 @@
 package com.pray2you.p2uhomepage.domain.rank.entity;
 
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "`rank`")
 public class Rank extends BaseTimeEntity {

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/reply/entity/Reply.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/reply/entity/Reply.java
@@ -3,13 +3,14 @@ package com.pray2you.p2uhomepage.domain.reply.entity;
 import com.pray2you.p2uhomepage.domain.board.entity.Board;
 import com.pray2you.p2uhomepage.domain.user.entity.User;
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Reply extends BaseTimeEntity {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/til/entity/Til.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/til/entity/Til.java
@@ -2,6 +2,7 @@ package com.pray2you.p2uhomepage.domain.til.entity;
 
 import com.pray2you.p2uhomepage.domain.user.entity.User;
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Til extends BaseTimeEntity {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/totalpoint/entity/TotalPoint.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/totalpoint/entity/TotalPoint.java
@@ -1,13 +1,14 @@
 package com.pray2you.p2uhomepage.domain.totalpoint.entity;
 
 import com.pray2you.p2uhomepage.domain.user.entity.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TotalPoint {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/user/entity/User.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.pray2you.p2uhomepage.domain.user.entity;
 
 import com.pray2you.p2uhomepage.domain.model.BaseTimeEntity;
 import com.pray2you.p2uhomepage.domain.model.Role;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class User extends BaseTimeEntity {
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/config/JpaAuditingConfiguration.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.pray2you.p2uhomepage.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/config/WebSecurityConfigure.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/config/WebSecurityConfigure.java
@@ -41,6 +41,8 @@ public class WebSecurityConfigure {
 
         //요청에 대한 권한 설정
         http.authorizeRequests()
+//                .antMatchers("/api/admin/**").hasRole("ADMIN")
+//                .antMatchers("/api/auth/**").permitAll()
                 .antMatchers("/**").permitAll()
                 .anyRequest().authenticated();
 

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/CommonErrorCode.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/CommonErrorCode.java
@@ -8,11 +8,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
 
-    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
-    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not exists"),
-    REQUEST_METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "This request method not supported"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
-    NOT_EXIST_URL(HttpStatus.NOT_FOUND, "Url does not exist"),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 parameter가 포함되었습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 자원입니다."),
+    REQUEST_METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "해당 요청은 잘못된 Method 요청 입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 에러 입니다."),
+    NOT_EXIST_URL(HttpStatus.NOT_FOUND, "존재하지 않는 요청입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/UserErrorCode.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/exception/ErrorCode/UserErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-    NOT_MATCHED_REDIRECT_URI(HttpStatus.BAD_REQUEST, "Redirect URIs are not matched"),
+    NOT_MATCHED_REDIRECT_URI(HttpStatus.BAD_REQUEST, "Redirect URI가 맞지 않습니다."),
+    DUPLICATE_APPROVAL_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 가입승인입니다."),
+    NOT_EXIST_APPROVAL_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 가입승인입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/security/handler/OAuth2AuthenticationFailureHandler.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/security/handler/OAuth2AuthenticationFailureHandler.java
@@ -4,6 +4,7 @@ import com.pray2you.p2uhomepage.global.security.repository.CookieAuthorizationRe
 import com.pray2you.p2uhomepage.global.security.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -23,6 +24,12 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+
+        if(exception instanceof OAuth2AuthenticationException){
+            response.sendRedirect("/");
+            return;
+        }
+
         String targetUrl = CookieUtil.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
                 .map(Cookie::getValue)
                 .orElse("/");

--- a/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/security/service/CustomOAuth2UserService.java
+++ b/p2uhomepage/src/main/java/com/pray2you/p2uhomepage/global/security/service/CustomOAuth2UserService.java
@@ -1,8 +1,11 @@
 package com.pray2you.p2uhomepage.global.security.service;
 
+import com.pray2you.p2uhomepage.domain.memberapproval.repository.MemberApprovalRepository;
 import com.pray2you.p2uhomepage.domain.model.Role;
 import com.pray2you.p2uhomepage.domain.user.entity.User;
 import com.pray2you.p2uhomepage.domain.user.repository.UserRepository;
+import com.pray2you.p2uhomepage.global.exception.ErrorCode.UserErrorCode;
+import com.pray2you.p2uhomepage.global.exception.RestApiException;
 import com.pray2you.p2uhomepage.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,16 +23,27 @@ import org.springframework.stereotype.Service;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final UserRepository userRepository;
+    private final MemberApprovalRepository memberApprovalRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
+
+
         OAuth2UserService oAuth2UserService = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = oAuth2UserService.loadUser(oAuth2UserRequest);
+
+        if(!checkMemberApproval(oAuth2User.getAttribute("login"))){
+            throw new OAuth2AuthenticationException("미승인 유저입니다.");
+        }
 
         User user = saveOrUpdate(oAuth2User);
         log.info(user.getGithubId());
 
         return CustomUserDetails.create(user, oAuth2User.getAttributes());
+    }
+
+    private boolean checkMemberApproval(String githubId){
+        return memberApprovalRepository.existsByGithubId(githubId);
     }
 
     private User saveOrUpdate(OAuth2User oAuth2User){

--- a/p2uhomepage/src/test/java/com/pray2you/p2uhomepage/domain/memberapproval/Service/MemberApprovalServiceTest.java
+++ b/p2uhomepage/src/test/java/com/pray2you/p2uhomepage/domain/memberapproval/Service/MemberApprovalServiceTest.java
@@ -1,0 +1,118 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.Service;
+
+import com.google.gson.Gson;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.request.CreateMemberApprovalRequestDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.CreateMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.DeleteMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.ReadMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.entity.MemberApproval;
+import com.pray2you.p2uhomepage.domain.memberapproval.repository.MemberApprovalRepository;
+import com.pray2you.p2uhomepage.domain.memberapproval.service.MemberApprovalService;
+import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class MemberApprovalServiceTest {
+
+    @Mock
+    private MemberApprovalRepository memberApprovalRepository;
+
+    @InjectMocks
+    private MemberApprovalService memberApprovalService;
+
+    @Test
+    @DisplayName("## 멤버 승인 등록 서비스 테스트 ##")
+    public void createMemberApprovals() {
+
+        StringBuilder memberApprovalCreateRequestJson = new StringBuilder();
+        memberApprovalCreateRequestJson.append("{")
+                .append("\"githubId\": \"gildong Hong\",")
+                .append("\"username\": \"honggildong\"")
+                .append("}");
+
+        CreateMemberApprovalRequestDTO createMemberApprovalRequestDTO = new Gson().fromJson(memberApprovalCreateRequestJson.toString(),CreateMemberApprovalRequestDTO.class);
+
+        MemberApproval memberApproval = new MemberApproval("gildong Hong", "honggildong", ApprovalStatus.APPROVED);
+
+        CreateMemberApprovalResponseDTO responseDTO = CreateMemberApprovalResponseDTO.toDTO(memberApproval);
+
+        //given
+        BDDMockito.given(memberApprovalRepository.findByGithubId(any())).willReturn(Optional.of(memberApproval));
+        BDDMockito.given(memberApprovalRepository.save(any())).willReturn(memberApproval);
+
+        //when
+        CreateMemberApprovalResponseDTO result = memberApprovalService.createMemberApprovals(createMemberApprovalRequestDTO);
+
+        //then
+        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(responseDTO);
+    }
+
+    @Test
+    @DisplayName("## 멤버 승인 삭제 서비스 테스트 ##")
+    public void deleteMemberApprovals() {
+
+        String githubId = "gildong Hong";
+
+        MemberApproval memberApproval = new MemberApproval("gildong Hong", "honggildong", ApprovalStatus.APPROVED);
+
+        MemberApproval deletedMemberApproval = new MemberApproval("gildong Hong", "honggildong", ApprovalStatus.DELETED);
+        DeleteMemberApprovalResponseDTO responseDTO = DeleteMemberApprovalResponseDTO.toDTO(deletedMemberApproval);
+
+        //given
+        BDDMockito.given(memberApprovalRepository.findByGithubId(any())).willReturn(Optional.of(memberApproval));
+
+        BDDMockito.given(memberApprovalRepository.save(any())).willReturn(deletedMemberApproval);
+
+        //when
+        DeleteMemberApprovalResponseDTO result = memberApprovalService.deleteMemberApprovals(githubId);
+
+        //then
+        //멤버 상태 deleted로 바꾼후 dto로 변경 후 결과 비교
+        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(responseDTO);
+    }
+
+    @Test
+    @DisplayName("## 멤버 승인 조회 서비스 테스트 ##")
+    public void getAllMemberApprovals() {
+
+        Pageable pageable = PageRequest.of(0, 5);
+
+        MemberApproval memberApproval = new MemberApproval("gildong Hong", "honggildong", ApprovalStatus.APPROVED);
+
+        List<MemberApproval> memberApprovalList = new ArrayList<>();
+        memberApprovalList.add(memberApproval);
+
+        Page<MemberApproval> memberApprovalPage = new PageImpl<>(memberApprovalList);
+
+        Page<ReadMemberApprovalResponseDTO> responseDTO = memberApprovalPage
+                .map(ReadMemberApprovalResponseDTO::toDTO);
+
+        //given
+        BDDMockito.given(memberApprovalRepository.findAll((Pageable) any())).willReturn(memberApprovalPage);
+
+
+        //when
+        Page<ReadMemberApprovalResponseDTO> result = memberApprovalService.getAllMemberApprovals(pageable);
+
+        //then
+        Assertions.assertThat(result).usingRecursiveComparison().isEqualTo(responseDTO);
+    }
+
+}

--- a/p2uhomepage/src/test/java/com/pray2you/p2uhomepage/domain/memberapproval/controller/MemberApprovalControllerTest.java
+++ b/p2uhomepage/src/test/java/com/pray2you/p2uhomepage/domain/memberapproval/controller/MemberApprovalControllerTest.java
@@ -1,0 +1,134 @@
+package com.pray2you.p2uhomepage.domain.memberapproval.controller;
+
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.CreateMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.DeleteMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.dto.response.ReadMemberApprovalResponseDTO;
+import com.pray2you.p2uhomepage.domain.memberapproval.service.MemberApprovalService;
+import com.pray2you.p2uhomepage.domain.model.ApprovalStatus;
+import com.pray2you.p2uhomepage.global.config.WebSecurityConfigure;
+import com.pray2you.p2uhomepage.global.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@WebMvcTest(controllers = MemberApprovalController.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {WebSecurityConfigure.class, JwtAuthenticationFilter.class})
+        })
+@AutoConfigureMockMvc(addFilters = false)
+class MemberApprovalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberApprovalService memberApprovalService;
+
+    @Test
+    @DisplayName("## 멤버 승인 등록 컨트롤러 테스트 ##")
+    void createMemberApprovals() throws Exception {
+        StringBuilder memberApprovalCreateRequestJson = new StringBuilder();
+        memberApprovalCreateRequestJson.append("{")
+                .append("\"githubId\": \"gildong Hong\",")
+                .append("\"username\": \"honggildong\"")
+                .append("}");
+
+        CreateMemberApprovalResponseDTO createMemberApprovalResponseDTO = CreateMemberApprovalResponseDTO.builder()
+                .memberApprovalId(1L)
+                .githubId("gildong Hong")
+                .username("honggildong")
+                .status(ApprovalStatus.APPROVED)
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
+                .build();
+
+        //given
+        BDDMockito.given(memberApprovalService.createMemberApprovals(any())).willReturn(createMemberApprovalResponseDTO);
+
+        String json = memberApprovalCreateRequestJson.toString();
+        //when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/api/admin/member-approvals")
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json));
+
+        //then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+
+
+
+    @Test
+    @DisplayName("## 멤버 승인 삭제 컨트롤러 테스트 ##")
+    void deleteMemberApprovals() throws Exception {
+
+        DeleteMemberApprovalResponseDTO deleteMemberApprovalResponseDTO = DeleteMemberApprovalResponseDTO.builder()
+                .githubId("gildong Hong")
+                .username("honggildong")
+                .status(ApprovalStatus.APPROVED)
+                .createDate(LocalDateTime.now())
+                .deletedDate(LocalDateTime.now())
+                .build();
+
+        //given
+        BDDMockito.given(memberApprovalService.deleteMemberApprovals(any())).willReturn(deleteMemberApprovalResponseDTO);
+
+        //when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/admin/member-approvals/gildong Hong")
+                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+        //then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("## 멤버 승인 전체 조회 컨트롤러 테스트 ##")
+    void getAllMemberApprovals() throws Exception {
+
+        ReadMemberApprovalResponseDTO responseDTO = ReadMemberApprovalResponseDTO.builder()
+                .memberApprovalId(1L)
+                .githubId("gildong Hong")
+                .username("honggildong")
+                .status(ApprovalStatus.APPROVED)
+                .createdDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
+                .build();
+
+        List<ReadMemberApprovalResponseDTO> responseDTOList = new ArrayList<>();
+        responseDTOList.add(responseDTO);
+
+        Page<ReadMemberApprovalResponseDTO> responseDTOPage = new PageImpl<>(responseDTOList);
+
+        //given
+        BDDMockito.given(memberApprovalService.getAllMemberApprovals(any())).willReturn(responseDTOPage);
+
+        //when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.get("/api/admin/member-approvals?page=0&size=1&sort=id,desc")
+                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+
+        //then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+}


### PR DESCRIPTION
- 유저승인, 삭제, 조회 구현
- 어드민 권한 구현했지만 테스트용도로 일단은 열어둔 상태
- entity 생성자 접근범위 재설정
- 컨트롤러, 서비스 테스트코드 구현